### PR TITLE
Cross-build for sbt 2.x / Scala 3, migrate release to sbt-ci-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,30 @@ jobs:
 
     strategy:
       matrix:
-        scala:
-          - 2.12.12
+        include:
+          - scala: 2.12.21
+            java: 11
+          - scala: 3.8.4
+            java: 17
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
-      - uses: coursier/cache-action@v5
+      - uses: coursier/cache-action@v8
+        continue-on-error: true
 
-      - name: scala
-        uses: olafurpg/setup-scala@v10
+      - uses: actions/setup-java@v5
         with:
-          java-version: openjdk@1.11
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+
+      - uses: sbt/setup-sbt@v1
 
       - name: build ${{ matrix.scala }}
         run: sbt ++${{ matrix.scala }} build
 
       - name: test coverage
-        if: success()
+        if: success() && matrix.scala == '2.12.21'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,52 @@
-name: Publish new Release
+name: release
 
 on:
-  release:
-    types: [published]
-    branches: [master]
+  push:
+    tags: [ "v*" ]
+
+# run only one release action at a time for the repo, wait for the previous to finish before running another one
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}
 
 jobs:
-  release:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v1
-    secrets: inherit
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Tags are needed for sbt-dynver to compute the version from the pushed tag.
+          fetch-depth: 0
+      - uses: coursier/cache-action@v8
+        continue-on-error: true
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+
+      # sbt ci-release doesn't verify the build, need to do it explicitly
+      - name: sbt build
+        run: sbt build
+
+      - run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+
+      - name: delete release tag if failed
+        if: failure()
+        run: git push --delete origin ${{ github.ref_name }}
+
+      - name: publish release notes
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+        run: |
+          gh release create "$tag" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="v${tag#v}" \
+              --generate-notes

--- a/build.sbt
+++ b/build.sbt
@@ -18,9 +18,27 @@ organizationHomepage := Some(url("https://evolution.com"))
 
 scalaVersion := crossScalaVersions.value.head
 
-crossScalaVersions := Seq("2.12.12")
+crossScalaVersions := Seq("2.12.21", "3.8.4")
 
-crossSbtVersions := Seq("1.5.0")
+(pluginCrossBuild / sbtVersion) := {
+  scalaBinaryVersion.value match {
+    case "2.12" => "1.5.0"
+    case _      => "2.0.3"
+  }
+}
+
+scriptedSbt := {
+  scalaBinaryVersion.value match {
+    case "2.12" => "1.5.0"
+    case _      => "2.0.3"
+  }
+}
+
+// the currently released sbt-scalac-opts-plugin (dogfooded on this very project via
+// project/plugins.sbt) always adds -Xfatal-warnings, which Scala 3 flags as a deprecated
+// alias and then fails on under -Werror; disable it for the Scala 3 leg until a Scala
+// 3-aware release of this plugin can be dogfooded on itself.
+scalacOptsFailOnWarn := (if (scalaBinaryVersion.value == "3") None else Some(true))
 
 publishMavenStyle := true
 
@@ -39,33 +57,6 @@ developers := List(
 
 
 versionScheme := Some("early-semver")
-
-sonatypeCredentialHost := "s01.oss.sonatype.org"
-
-sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
-
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
-
-//publishTo := sonatypePublishToBundle.value
-publishTo := Some(Resolver.evolutionReleases)
-
-import ReleaseTransformations._
-
-releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
-releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,
-  inquireVersions,
-  runClean,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  releaseStepCommandAndRemaining("publishSigned"),
-  releaseStepCommand("sonatypeBundleRelease"),
-  setNextVersion,
-  commitNextVersion,
-  pushChanges
-)
 
 scriptedBufferLog := false
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.12.14

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,10 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
-
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
-
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
+// sbt-coveralls has no sbt2/Scala 3 build, only needed for the Scala 2.12 leg
+if (scala.util.Properties.versionNumberString.startsWith("2.12"))
+  Seq(addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15"))
+else Seq.empty
 
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
-
-addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.0.2")

--- a/src/main/scala/com/evolution/scalacopts/ScalacOptsPlugin.scala
+++ b/src/main/scala/com/evolution/scalacopts/ScalacOptsPlugin.scala
@@ -44,65 +44,65 @@ object ScalacOptsPlugin extends AutoPlugin {
   implicit def intToScalaVersion(minor: Int): ScalaVersion = ScalaVersion(minor)
 
   val scalacOptsAll = List(
-    ScalacOpt("-deprecation") until 13,                         // Emit warning and location for usages of deprecated APIs. Not really removed but deprecated in 2.13.
-    ScalacOpt("-explaintypes"),                                 // Explain type errors in more detail.
-    ScalacOpt("-feature"),                                      // Emit warning and location for usages of features that should be imported explicitly.
-    ScalacOpt("-language:existentials"),                        // Existential types (besides wildcard types) can be written and inferred
-    ScalacOpt("-language:experimental.macros"),                 // Allow macro definition (besides implementation and application)
-    ScalacOpt("-language:higherKinds"),                         // Allow higher-kinded types
-    ScalacOpt("-language:implicitConversions"),                 // Allow definition of implicit functions called views
-    ScalacOpt("-unchecked"),                                    // Enable additional warnings where generated code depends on assumptions.
-    ScalacOpt("-Xcheckinit"),                                   // Wrap field accessors to throw an exception on uninitialized access.
-    ScalacOpt("-Xfatal-warnings"),                              // Fail the compilation if there are any warnings.
-    ScalacOpt("-Xfuture") until 13,                             // Turn on future language features. This is not really removed in 2.13 but is replaced by -Xsource which requires the user to choose which language version they want.
-    ScalacOpt("-Xlog-reflective-calls"),                        // Print a message when a reflective method call is generated
-    ScalacOpt("-Xlint") until 11,                               // Used to mean enable all linting options but now the syntax for that is different (-Xlint:_ I think)
-    ScalacOpt("-Xlint:adapted-args"),                           // Warn if an argument list is modified to match the receiver.
-    ScalacOpt("-Xlint:by-name-right-associative") until 13,     // By-name parameter of right associative operator.
-    ScalacOpt("-Xlint:constant") since 12,                      // Evaluation of a constant arithmetic expression results in an error.
-    ScalacOpt("-Xlint:delayedinit-select"),                     // Selecting member of DelayedInit.
-    ScalacOpt("-Xlint:deprecation") since 13,                   // Emit warning and location for usages of deprecated APIs.
-    ScalacOpt("-Xlint:doc-detached"),                           // A Scaladoc comment appears to be detached from its element.
-    ScalacOpt("-Xlint:inaccessible"),                           // Warn about inaccessible types in method signatures.
-    ScalacOpt("-Xlint:infer-any"),                              // Warn when a type argument is inferred to be `Any`.
-    ScalacOpt("-Xlint:missing-interpolator"),                   // A string literal appears to be missing an interpolator id.
-    ScalacOpt("-Xlint:nullary-override") until 13,              // Warn when non-nullary `def f()' overrides nullary `def f'.
-    ScalacOpt("-Xlint:nullary-unit"),                           // Warn when nullary methods return Unit.
-    ScalacOpt("-Xlint:option-implicit"),                        // Option.apply used implicit view.
-    ScalacOpt("-Xlint:package-object-classes"),                 // Class or object defined in package object.
-    ScalacOpt("-Xlint:poly-implicit-overload"),                 // Parameterized overloaded implicit methods are not visible as view bounds.
-    ScalacOpt("-Xlint:private-shadow"),                         // A private field (or class parameter) shadows a superclass field.
-    ScalacOpt("-Xlint:stars-align"),                            // Pattern sequence wildcard must align with sequence component.
-    ScalacOpt("-Xlint:type-parameter-shadow"),                  // A local type parameter shadows a type already in scope.
-    ScalacOpt("-Xlint:unsound-match") until 13,                 // Pattern match may not be typesafe.
-    ScalacOpt("-Ywarn-macros:after"),                           // Enable lint warnings on macro expansions: Only inspect expanded trees when generating unused symbol warnings.
-    ScalacOpt("-Yno-adapted-args") until 13,                    // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-    ScalacOpt("-Ypartial-unification") until 13,                // Enable partial unification in type constructor inference
-    ScalacOpt("-Ywarn-dead-code") until 13,                     // Warn when dead code is identified.
-    ScalacOpt("-Wdead-code") since 13,                          // ^ Replaces the above
-    ScalacOpt("-Ywarn-extra-implicit") since 12 until 13,       // Warn when more than one implicit parameter section is defined.
-    ScalacOpt("-Wextra-implicit") since 13,                     // ^ Replaces the above
-    ScalacOpt("-Ywarn-inaccessible") until  11,                 // Warn about inaccessible types in method signatures. Alias for -Xlint:inaccessible so can be removed as of 2.11.
-    ScalacOpt("-Ywarn-nullary-override") until 13,              // Warn when non-nullary `def f()' overrides nullary `def f'.
-    ScalacOpt("-Ywarn-nullary-unit") until 13,                  // Warn when nullary methods return Unit.
-    ScalacOpt("-Ywarn-numeric-widen") until 13,                 // Warn when numerics are widened.
-    ScalacOpt("-Wnumeric-widen") since 13,                      // ^ Replaces the above
-    ScalacOpt("-Ywarn-unused-import") until 12,                 // Warn if an import selector is not referenced.
-    ScalacOpt("-Ywarn-unused:implicits") since 12 until 13,     // Warn if an implicit parameter is unused.
-    ScalacOpt("-Wunused:implicits") since 13,                   // ^ Replaces the above
-    ScalacOpt("-Ywarn-unused:imports") since 12 until 13,       // Warn if an import selector is not referenced.
-    ScalacOpt("-Wunused:imports") since 13,                     // ^ Replaces the above
-    ScalacOpt("-Ywarn-unused:locals") since 12 until 13,        // Warn if a local definition is unused.
-    ScalacOpt("-Wunused:locals") since 13,                      // ^ Replaces the above
-    ScalacOpt("-Ywarn-unused:params") since 12 until 13,        // Warn if a value parameter is unused.
-    ScalacOpt("-Wunused:params") since 13,                      // ^ Replaces the above
-    ScalacOpt("-Ywarn-unused:patvars") since 12 until 13,       // Warn if a variable bound in a pattern is unused.
-    ScalacOpt("-Wunused:patvars") since 13,                     // ^ Replaces the above
-    ScalacOpt("-Ywarn-unused:privates") since 12 until 13,      // Warn if a private member is unused.
-    ScalacOpt("-Wunused:privates") since 13,                    // ^ Replaces the above
-    ScalacOpt("-Ywarn-value-discard") until 13,                 // Warn when non-Unit expression results are unused.
-    ScalacOpt("-Wvalue-discard") since 13,                      // ^ Replaces the above
-    ScalacOpt("-Wnonunit-statement") since ScalaVersion(13, 9), // Warn when expression is ignored because it is followed by another expression.
+    ScalacOpt("-deprecation").until(13),                         // Emit warning and location for usages of deprecated APIs. Not really removed but deprecated in 2.13.
+    ScalacOpt("-explaintypes"),                                  // Explain type errors in more detail.
+    ScalacOpt("-feature"),                                       // Emit warning and location for usages of features that should be imported explicitly.
+    ScalacOpt("-language:existentials"),                         // Existential types (besides wildcard types) can be written and inferred
+    ScalacOpt("-language:experimental.macros"),                  // Allow macro definition (besides implementation and application)
+    ScalacOpt("-language:higherKinds"),                          // Allow higher-kinded types
+    ScalacOpt("-language:implicitConversions"),                  // Allow definition of implicit functions called views
+    ScalacOpt("-unchecked"),                                     // Enable additional warnings where generated code depends on assumptions.
+    ScalacOpt("-Xcheckinit"),                                    // Wrap field accessors to throw an exception on uninitialized access.
+    ScalacOpt("-Xfatal-warnings"),                               // Fail the compilation if there are any warnings.
+    ScalacOpt("-Xfuture").until(13),                             // Turn on future language features. This is not really removed in 2.13 but is replaced by -Xsource which requires the user to choose which language version they want.
+    ScalacOpt("-Xlog-reflective-calls"),                         // Print a message when a reflective method call is generated
+    ScalacOpt("-Xlint").until(11),                               // Used to mean enable all linting options but now the syntax for that is different (-Xlint:_ I think)
+    ScalacOpt("-Xlint:adapted-args"),                            // Warn if an argument list is modified to match the receiver.
+    ScalacOpt("-Xlint:by-name-right-associative").until(13),     // By-name parameter of right associative operator.
+    ScalacOpt("-Xlint:constant").since(12),                      // Evaluation of a constant arithmetic expression results in an error.
+    ScalacOpt("-Xlint:delayedinit-select"),                      // Selecting member of DelayedInit.
+    ScalacOpt("-Xlint:deprecation").since(13),                   // Emit warning and location for usages of deprecated APIs.
+    ScalacOpt("-Xlint:doc-detached"),                            // A Scaladoc comment appears to be detached from its element.
+    ScalacOpt("-Xlint:inaccessible"),                            // Warn about inaccessible types in method signatures.
+    ScalacOpt("-Xlint:infer-any"),                               // Warn when a type argument is inferred to be `Any`.
+    ScalacOpt("-Xlint:missing-interpolator"),                    // A string literal appears to be missing an interpolator id.
+    ScalacOpt("-Xlint:nullary-override").until(13),              // Warn when non-nullary `def f()' overrides nullary `def f'.
+    ScalacOpt("-Xlint:nullary-unit"),                            // Warn when nullary methods return Unit.
+    ScalacOpt("-Xlint:option-implicit"),                         // Option.apply used implicit view.
+    ScalacOpt("-Xlint:package-object-classes"),                  // Class or object defined in package object.
+    ScalacOpt("-Xlint:poly-implicit-overload"),                  // Parameterized overloaded implicit methods are not visible as view bounds.
+    ScalacOpt("-Xlint:private-shadow"),                          // A private field (or class parameter) shadows a superclass field.
+    ScalacOpt("-Xlint:stars-align"),                             // Pattern sequence wildcard must align with sequence component.
+    ScalacOpt("-Xlint:type-parameter-shadow"),                   // A local type parameter shadows a type already in scope.
+    ScalacOpt("-Xlint:unsound-match").until(13),                 // Pattern match may not be typesafe.
+    ScalacOpt("-Ywarn-macros:after"),                            // Enable lint warnings on macro expansions: Only inspect expanded trees when generating unused symbol warnings.
+    ScalacOpt("-Yno-adapted-args").until(13),                    // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+    ScalacOpt("-Ypartial-unification").until(13),                // Enable partial unification in type constructor inference
+    ScalacOpt("-Ywarn-dead-code").until(13),                     // Warn when dead code is identified.
+    ScalacOpt("-Wdead-code").since(13),                          // ^ Replaces the above
+    ScalacOpt("-Ywarn-extra-implicit").since(12).until(13),      // Warn when more than one implicit parameter section is defined.
+    ScalacOpt("-Wextra-implicit").since(13),                     // ^ Replaces the above
+    ScalacOpt("-Ywarn-inaccessible").until(11),                  // Warn about inaccessible types in method signatures. Alias for -Xlint:inaccessible so can be removed as of 2.11.
+    ScalacOpt("-Ywarn-nullary-override").until(13),              // Warn when non-nullary `def f()' overrides nullary `def f'.
+    ScalacOpt("-Ywarn-nullary-unit").until(13),                  // Warn when nullary methods return Unit.
+    ScalacOpt("-Ywarn-numeric-widen").until(13),                 // Warn when numerics are widened.
+    ScalacOpt("-Wnumeric-widen").since(13),                      // ^ Replaces the above
+    ScalacOpt("-Ywarn-unused-import").until(12),                 // Warn if an import selector is not referenced.
+    ScalacOpt("-Ywarn-unused:implicits").since(12).until(13),    // Warn if an implicit parameter is unused.
+    ScalacOpt("-Wunused:implicits").since(13),                   // ^ Replaces the above
+    ScalacOpt("-Ywarn-unused:imports").since(12).until(13),      // Warn if an import selector is not referenced.
+    ScalacOpt("-Wunused:imports").since(13),                     // ^ Replaces the above
+    ScalacOpt("-Ywarn-unused:locals").since(12).until(13),       // Warn if a local definition is unused.
+    ScalacOpt("-Wunused:locals").since(13),                      // ^ Replaces the above
+    ScalacOpt("-Ywarn-unused:params").since(12).until(13),       // Warn if a value parameter is unused.
+    ScalacOpt("-Wunused:params").since(13),                      // ^ Replaces the above
+    ScalacOpt("-Ywarn-unused:patvars").since(12).until(13),      // Warn if a variable bound in a pattern is unused.
+    ScalacOpt("-Wunused:patvars").since(13),                     // ^ Replaces the above
+    ScalacOpt("-Ywarn-unused:privates").since(12).until(13),     // Warn if a private member is unused.
+    ScalacOpt("-Wunused:privates").since(13),                    // ^ Replaces the above
+    ScalacOpt("-Ywarn-value-discard").until(13),                 // Warn when non-Unit expression results are unused.
+    ScalacOpt("-Wvalue-discard").since(13),                      // ^ Replaces the above
+    ScalacOpt("-Wnonunit-statement").since(ScalaVersion(13, 9)), // Warn when expression is ignored because it is followed by another expression.
   )
 
 
@@ -140,12 +140,12 @@ object ScalacOptsPlugin extends AutoPlugin {
         "-Ywarn-dead-code",
         "-Xfatal-warnings")
 
-      opts: Seq[String] => opts.filterNot(exclude)
+      (opts: Seq[String]) => opts.filterNot(exclude)
     }
 
     def failOnWarn(failOnWarn: Option[Boolean]): Seq[String] => Seq[String] = {
       val opt = "-Xfatal-warnings"
-      opts: Seq[String] =>
+      (opts: Seq[String]) =>
         failOnWarn.fold(opts) {
           case true  => if (opts contains opt) opts else opts :+ opt
           case false => opts.filter(_ != opt)
@@ -155,7 +155,7 @@ object ScalacOptsPlugin extends AutoPlugin {
 
   import autoImport._
 
-  override def projectSettings: Seq[Setting[_]] = List(
+  override def projectSettings = List(
     scalacOptsFailOnWarn := Some(true),
     scalacOptions ++= failOnWarn(scalacOptsFailOnWarn.value)(scalacOptsFor(scalaVersion.value, scalacOptsAll)),
     Compile / console / scalacOptions ~= filterConsoleScalacOpts,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.0.10-SNAPSHOT"


### PR DESCRIPTION
## Summary
- Cross-build for Scala 2.12.21 + Scala 3.8.4, publishing sbt1 and sbt2 plugin variants via `pluginCrossBuild`/`scriptedSbt`
- Bump sbt-scoverage to 2.4.4, gate sbt-coveralls to the 2.12 leg only (no sbt2 build), bump project sbt to 1.12.14
- Fix plugin source for Scala 3 (infix calls, lambda syntax); scope out `-Xfatal-warnings` for the Scala 3 leg (bug in the currently-released dogfooded version)
- CI: matrix over both Scala versions with matching JDKs (11/17), bump actions to current majors
- Replace manual sbt-release/sbt-pgp/sbt-sonatype + JFrog publish with sbt-ci-release (Sonatype), drop version.sbt (sbt-dynver)